### PR TITLE
Update password and logout

### DIFF
--- a/app/src/main/java/com/example/octochat/ChangePasswordFragment.kt
+++ b/app/src/main/java/com/example/octochat/ChangePasswordFragment.kt
@@ -52,13 +52,15 @@ class ChangePasswordFragment : Fragment() {
         if(newPsw != newConfirmPsw) {
             Toast.makeText(
                 activity,
-                "Passwords does not match",
+                //"Passwords does not match",
+                getString(R.string.settings_toast_password_mismatch),
                 Toast.LENGTH_SHORT
             ).show();
         } else if (newPsw.length < 9) {
             Toast.makeText(
                 activity,
-                "Passwords length is too short - a password length of 9 or more is required",
+                //"Passwords length is too short - a password length of 9 or more is required",
+                getString(R.string.settings_toast_password_too_short),
                 Toast.LENGTH_SHORT
             ).show();
         } else {
@@ -66,14 +68,16 @@ class ChangePasswordFragment : Fragment() {
                 if(task.isSuccessful) {
                     Toast.makeText(
                         activity,
-                        "Password updated",
+                        //"Password updated",
+                        getString(R.string.settings_toast_password_successful),
                         Toast.LENGTH_SHORT
                     ).show();
                     (activity as SettingsActivity).removeChangePasswordFragment()
                 } else {
                     Toast.makeText(
                         activity,
-                        "Something went wrong - please try again",
+                        //"Something went wrong - please try again",
+                        getString(R.string.settings_general_error),
                         Toast.LENGTH_SHORT
                     ).show()
                 }

--- a/app/src/main/java/com/example/octochat/ChangePasswordFragment.kt
+++ b/app/src/main/java/com/example/octochat/ChangePasswordFragment.kt
@@ -50,33 +50,33 @@ class ChangePasswordFragment : Fragment() {
         var newConfirmPsw = confirmNewPassword.text.toString()
 
         if(newPsw != newConfirmPsw) {
+            //triggers if password fields does not match
             Toast.makeText(
                 activity,
-                //"Passwords does not match",
                 getString(R.string.settings_toast_password_mismatch),
                 Toast.LENGTH_SHORT
             ).show();
         } else if (newPsw.length < 9) {
+            //triggers if the password is shorter than 9 characters
             Toast.makeText(
                 activity,
-                //"Passwords length is too short - a password length of 9 or more is required",
                 getString(R.string.settings_toast_password_too_short),
                 Toast.LENGTH_SHORT
             ).show();
         } else {
+            //triggers if none of the above are true
             currentUser!!.updatePassword(newPsw).addOnCompleteListener{ task ->
                 if(task.isSuccessful) {
                     Toast.makeText(
                         activity,
-                        //"Password updated",
                         getString(R.string.settings_toast_password_successful),
                         Toast.LENGTH_SHORT
                     ).show();
                     (activity as SettingsActivity).removeChangePasswordFragment()
                 } else {
+                    //triggers if there is an error while updating to firestore
                     Toast.makeText(
                         activity,
-                        //"Something went wrong - please try again",
                         getString(R.string.settings_general_error),
                         Toast.LENGTH_SHORT
                     ).show()

--- a/app/src/main/java/com/example/octochat/ChangePasswordFragment.kt
+++ b/app/src/main/java/com/example/octochat/ChangePasswordFragment.kt
@@ -1,16 +1,20 @@
 package com.example.octochat
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
+import android.widget.Toast
 import androidx.fragment.app.Fragment
+import com.google.firebase.auth.FirebaseAuth
 
 class ChangePasswordFragment : Fragment() {
 
-    lateinit var currentPasswordInput : TextView
+    lateinit var auth: FirebaseAuth
+
     lateinit var newPasswordInput : TextView
     lateinit var confirmNewPassword : TextView
 
@@ -22,7 +26,8 @@ class ChangePasswordFragment : Fragment() {
 
         val view = inflater.inflate(R.layout.fragment_password_change, container,false)
 
-        currentPasswordInput = view.findViewById(R.id.currentPasswordInput)
+        auth = FirebaseAuth.getInstance()
+
         newPasswordInput = view.findViewById(R.id.newPasswordInput)
         confirmNewPassword = view.findViewById(R.id.newPasswordConfirmInput)
 
@@ -30,7 +35,7 @@ class ChangePasswordFragment : Fragment() {
         var cancelButton = view.findViewById<Button>(R.id.cancelButton)
 
         saveButton.setOnClickListener {
-            //save password and close fragment - display toast IF save is successful
+            matchAndUpdatePassword()
         }
 
         cancelButton.setOnClickListener {
@@ -39,4 +44,40 @@ class ChangePasswordFragment : Fragment() {
         return view
     }
 
+    private fun matchAndUpdatePassword() {
+        val currentUser = auth.currentUser
+        var newPsw = newPasswordInput.text.toString()
+        var newConfirmPsw = confirmNewPassword.text.toString()
+
+        if(newPsw != newConfirmPsw) {
+            Toast.makeText(
+                activity,
+                "Passwords does not match",
+                Toast.LENGTH_SHORT
+            ).show();
+        } else if (newPsw.length < 9) {
+            Toast.makeText(
+                activity,
+                "Passwords length is too short - a password length of 9 or more is required",
+                Toast.LENGTH_SHORT
+            ).show();
+        } else {
+            currentUser!!.updatePassword(newPsw).addOnCompleteListener{ task ->
+                if(task.isSuccessful) {
+                    Toast.makeText(
+                        activity,
+                        "Password updated",
+                        Toast.LENGTH_SHORT
+                    ).show();
+                    (activity as SettingsActivity).removeChangePasswordFragment()
+                } else {
+                    Toast.makeText(
+                        activity,
+                        "Something went wrong - please try again",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/octochat/SettingsActivity.kt
+++ b/app/src/main/java/com/example/octochat/SettingsActivity.kt
@@ -3,8 +3,10 @@ package com.example.octochat
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
 
 class SettingsActivity : AppCompatActivity() {
 
@@ -18,18 +20,6 @@ class SettingsActivity : AppCompatActivity() {
         setContentView(R.layout.activity_settings)
 
         auth = FirebaseAuth.getInstance()
-
-        var currentUser = auth.currentUser
-
-        /*
-        currentUser?.let {
-            var userName = currentUser.displayName
-            var email = currentUser.email
-            Log.d("!!!", "username: $userName")
-            Log.d("!!!", "email: $email")
-        }
-
-         */
 
         changePasswordButton = findViewById(R.id.changePasswordConstraint)
         logoutConstraint = findViewById(R.id.logoutConstraint)

--- a/app/src/main/java/com/example/octochat/SettingsActivity.kt
+++ b/app/src/main/java/com/example/octochat/SettingsActivity.kt
@@ -1,14 +1,14 @@
 package com.example.octochat
 
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.util.Log
-import android.widget.ImageView
 import androidx.constraintlayout.widget.ConstraintLayout
+import com.google.firebase.auth.FirebaseAuth
 
 class SettingsActivity : AppCompatActivity() {
 
-    //private lateinit var navigateBackButton : ImageView
+    lateinit var auth: FirebaseAuth
     private lateinit var changePasswordButton : ConstraintLayout
     private lateinit var logoutConstraint : ConstraintLayout
 
@@ -17,26 +17,31 @@ class SettingsActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_settings)
 
-        //navigateBackButton = findViewById(R.id.navigateBackButton)
-        changePasswordButton = findViewById(R.id.changePasswordConstraint)
-        logoutConstraint = findViewById(R.id.logoutConstraint)
+        auth = FirebaseAuth.getInstance()
+
+        var currentUser = auth.currentUser
 
         /*
-        navigateBackButton.setOnClickListener {
-            finish()
+        currentUser?.let {
+            var userName = currentUser.displayName
+            var email = currentUser.email
+            Log.d("!!!", "username: $userName")
+            Log.d("!!!", "email: $email")
         }
 
          */
 
+        changePasswordButton = findViewById(R.id.changePasswordConstraint)
+        logoutConstraint = findViewById(R.id.logoutConstraint)
+
         changePasswordButton.setOnClickListener{
-            //Toggle changePassword fragment
             displayChangePasswordFragment()
         }
 
         logoutConstraint.setOnClickListener{
-            //Logout current user
-            Log.d("!!!", "Click!")
+            logoutUser()
         }
+
     }
 
     fun displayChangePasswordFragment() {
@@ -54,4 +59,11 @@ class SettingsActivity : AppCompatActivity() {
             transaction.commit()
         }
     }
+
+    fun logoutUser() {
+        val intent = Intent(this, MainActivity::class.java)
+        auth.signOut()
+        startActivity(intent)
+    }
+
 }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -57,7 +57,7 @@
                 android:id="@+id/changePasswordConstraint"
                 android:layout_width="300dp"
                 android:layout_height="50dp"
-                android:layout_marginBottom="50dp"
+                android:layout_marginBottom="35dp"
                 app:layout_constraintBottom_toTopOf="@+id/logoutConstraint"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent">

--- a/app/src/main/res/layout/fragment_password_change.xml
+++ b/app/src/main/res/layout/fragment_password_change.xml
@@ -8,9 +8,11 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:layout_marginStart="25dp"
+        android:layout_marginTop="25dp"
         android:layout_marginEnd="25dp"
+        android:layout_marginBottom="25dp"
         android:background="@drawable/grad"
         android:clickable="true"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -31,31 +33,17 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <EditText
-            android:id="@+id/currentPasswordInput"
-            android:layout_width="235dp"
-            android:layout_height="45dp"
-            android:layout_marginTop="50dp"
-            android:autoText="false"
-            android:ems="10"
-            android:hint="@string/settings_change_password_current_password"
-            android:inputType="textPersonName"
-            android:password="true"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/changePasswordFragmentHeadText" />
-
-        <EditText
             android:id="@+id/newPasswordInput"
             android:layout_width="235dp"
             android:layout_height="45dp"
-            android:layout_marginTop="25dp"
+            android:layout_marginTop="50dp"
             android:ems="10"
             android:hint="@string/settings_change_password_new_password"
             android:inputType="textPersonName"
             android:password="true"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/currentPasswordInput" />
+            app:layout_constraintTop_toBottomOf="@+id/changePasswordFragmentHeadText" />
 
         <EditText
             android:id="@+id/newPasswordConfirmInput"
@@ -74,7 +62,7 @@
             android:id="@+id/saveButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="88dp"
+            android:layout_marginStart="75dp"
             android:layout_marginTop="75dp"
             android:layout_marginBottom="50dp"
             android:background="#FFFFFF"
@@ -82,21 +70,23 @@
             android:textSize="18sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/newPasswordConfirmInput" />
+            app:layout_constraintTop_toBottomOf="@+id/newPasswordConfirmInput"
+            app:layout_constraintVertical_bias="1.0" />
 
         <Button
             android:id="@+id/cancelButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="75dp"
-            android:layout_marginEnd="88dp"
+            android:layout_marginEnd="75dp"
             android:layout_marginBottom="50dp"
-            android:background="@drawable/grad"
+            android:background="@color/colorPrimaryDark"
             android:text="@string/settings_change_password_cancel"
             android:textSize="18sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/newPasswordConfirmInput" />
+            app:layout_constraintTop_toBottomOf="@+id/newPasswordConfirmInput"
+            app:layout_constraintVertical_bias="1.0" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -9,4 +9,8 @@
     <string name="settings_change_password_new_password_again">Ange nytt lösenord igen</string>
     <string name="settings_change_password_save">Spara</string>
     <string name="settings_change_password_cancel">Avbryt</string>
+    <string name="settings_toast_password_mismatch">Det angivna lösenordet matchar inte</string>
+    <string name="settings_toast_password_too_short">Lösenordet är för kort - lösenordet måste vara på 9 tecken eller mer</string>
+    <string name="settings_toast_password_successful">Lösenord uppdaterat</string>
+    <string name="settings_general_error">Något gick fel - försök igen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,8 @@
     <string name="settings_change_password_new_password_again">Enter new password again</string>
     <string name="settings_change_password_save">Save</string>
     <string name="settings_change_password_cancel">Cancel</string>
+    <string name="settings_toast_password_mismatch">Passwords does not match</string>
+    <string name="settings_toast_password_too_short">Passwords length is too short - a password length of 9 or more is required</string>
+    <string name="settings_toast_password_successful">Password updated</string>
+    <string name="settings_general_error">Something went wrong - please try again</string>
 </resources>


### PR DESCRIPTION
### Added functionality to logout current user and update their password
- The options Change Password and Logout in the SettingsActivity now has proper functionality tied to them
#### How to test
- Log in and go to Settings
- Tapping Change Password should open a new fragment, displaying two fields: New Password and Confirm New Password
- The Password needs to be 9 characters or longer (to sync with the requirements when logging in/register new users) and match in both fields. Should any of these requirements not be fulfilled an error message should be displayed when attempting to update the password.
- Tapping Logout logs out the user and navigates them back to the login view
