### PR TITLE
Updated rules when changing password

### DIFF
--- a/app/src/main/java/com/example/octochat/ChangePasswordFragment.kt
+++ b/app/src/main/java/com/example/octochat/ChangePasswordFragment.kt
@@ -56,8 +56,8 @@ class ChangePasswordFragment : Fragment() {
                 getString(R.string.settings_toast_password_mismatch),
                 Toast.LENGTH_SHORT
             ).show();
-        } else if (newPsw.length < 9) {
-            //triggers if the password is shorter than 9 characters
+        } else if (newPsw.length < 8) {
+            //triggers if the password is shorter than 8 characters
             Toast.makeText(
                 activity,
                 getString(R.string.settings_toast_password_too_short),

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -10,7 +10,7 @@
     <string name="settings_change_password_save">Spara</string>
     <string name="settings_change_password_cancel">Avbryt</string>
     <string name="settings_toast_password_mismatch">Det angivna lösenordet matchar inte</string>
-    <string name="settings_toast_password_too_short">Lösenordet är för kort - lösenordet måste vara på 9 tecken eller mer</string>
+    <string name="settings_toast_password_too_short">Lösenordet är för kort - lösenordet måste vara på 8 tecken eller fler</string>
     <string name="settings_toast_password_successful">Lösenord uppdaterat</string>
     <string name="settings_general_error">Något gick fel - försök igen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="settings_change_password_save">Save</string>
     <string name="settings_change_password_cancel">Cancel</string>
     <string name="settings_toast_password_mismatch">Passwords does not match</string>
-    <string name="settings_toast_password_too_short">Passwords length is too short - a password length of 9 or more is required</string>
+    <string name="settings_toast_password_too_short">Passwords length is too short - a password length of 8 or more is required</string>
     <string name="settings_toast_password_successful">Password updated</string>
     <string name="settings_general_error">Something went wrong - please try again</string>
     <string name="type_a_message">Type a message</string>


### PR DESCRIPTION
- Changing password now requires a password of 8 characters or more (to match rules for logging in)