### PR TITLE
Bugfix - Resolved unexpected welcome message

### DIFF
--- a/app/src/main/java/com/example/octochat/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/example/octochat/ui/login/LoginActivity.kt
@@ -163,7 +163,14 @@ class LoginActivity : AppCompatActivity() {
                 ).show()
                 finish()
 
-            } else Log.e("updateUiWithUser", it.exception.toString())
+            } else {
+                Log.e("updateUiWithUser", it.exception.toString())
+                Toast.makeText(
+                    applicationContext,
+                    getString(R.string.login_failed),
+                    Toast.LENGTH_LONG
+                ).show()
+            }
         }
 
 

--- a/app/src/main/java/com/example/octochat/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/example/octochat/ui/login/LoginActivity.kt
@@ -156,17 +156,19 @@ class LoginActivity : AppCompatActivity() {
 
                 db.collection("users").document(user!!.uid).set(User(user.uid, username,username, "New user"))
 //                user = auth.currentUser
+                Toast.makeText(
+                    applicationContext,
+                    "$welcome $displayName",
+                    Toast.LENGTH_LONG
+                ).show()
                 finish()
+
             } else Log.e("updateUiWithUser", it.exception.toString())
         }
 
 
         // TODO : initiate successful logged in experience
-        Toast.makeText(
-            applicationContext,
-            "$welcome $displayName",
-            Toast.LENGTH_LONG
-        ).show()
+
 
       //  readFirestoreData()
     }

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">octochat</string>
+    <string name="login_failed">"Inloggning misslyckades"</string>
     <string name="settings_banner">Inställningar</string>
     <string name="settings_change_password">Byt lösenord</string>
     <string name="settings_logout">Logga ut</string>


### PR DESCRIPTION
- Fixed the issue where a welcome message was displayed even if the user was unable to login
- Added toast message if login failed

#### How to test
- If you login successfully, a toast message appears with a welcome message
- If you fail to login (incorrect credentials) a toast message appears, saying login was unsuccessful