### PR TITLE
Error message upon failed registration

### DIFF
--- a/app/src/main/java/com/example/octochat/ui/create/CreateUserProfile.kt
+++ b/app/src/main/java/com/example/octochat/ui/create/CreateUserProfile.kt
@@ -166,7 +166,11 @@ class CreateUserProfile : AppCompatActivity()  {
 
                 }
                 else {
-                    Log.d("TestAgain", "Unable to create: ${task.exception}")
+                    Toast.makeText(
+                        applicationContext,
+                        "${getString(R.string.registration_signup_failed)} - ${task.exception?.message}",
+                        Toast.LENGTH_LONG
+                    ).show()
                 }
             }
     }

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -34,6 +34,7 @@
     <string name="repeat_password">Upprepa lösenord</string>
     <string name="password">Lösenord</string>
     <string name="create_account">Skapa konto</string>
+    <string name="registration_signup_failed">Registrering misslyckades</string>
     <string name="cancel">Avbryt</string>
     <string name="invalid_password">Lösenord måste vara minst 8 tecken</string>
     <string name="sign_in">Logga in</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="repeat_password">Repeat Password</string>
     <string name="password">Password</string>
     <string name="create_account">Create Account</string>
+    <string name="registration_signup_failed">Registration failed</string>
     <string name="cancel">Cancel</string>
     <string name="sign_in">Sign in</string>
     <string name="recover_password">Recover Password</string>


### PR DESCRIPTION
#### Added functionality
- If signup of a new user fails, an error message is displayed along with the reason of why registration failed

#### How to test
- Start registration of a new user
- Enter an e-mail adress already in use by another user
- Upon trying to complete the registration, a toast message should appear, saying the e-mail adress is already in use

#### Known issues
- If phone language is set to Swedish, the actual cause of the problem is still displayed in English